### PR TITLE
Add patch to fix freedv_api.h that is missing a <complex.h> include.

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 macos_machine:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,5 +1,5 @@
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 m2w64_c_compiler:

--- a/recipe/0001-Fix-CMake-include-of-GetPrerequisites.patch
+++ b/recipe/0001-Fix-CMake-include-of-GetPrerequisites.patch
@@ -21,5 +21,5 @@ index 0d25f670..cfb13230 100644
  foreach(_runtime ${_deps})
      message("Looking for ${_runtime}")
 -- 
-2.25.1
+2.32.0
 

--- a/recipe/0002-Add-optional-installation-of-command-line-programs.patch
+++ b/recipe/0002-Add-optional-installation-of-command-line-programs.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] Add optional installation of command-line programs.
  1 file changed, 46 insertions(+)
 
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 698910b9..d60c0b42 100644
+index 7f48ad5f..c82dc1c8 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -397,3 +397,49 @@ install(TARGETS codec2 EXPORT codec2-config
+@@ -399,3 +399,49 @@ install(TARGETS codec2 EXPORT codec2-config
      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
      PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/codec2 COMPONENT dev
  )
@@ -62,5 +62,5 @@ index 698910b9..d60c0b42 100644
 +    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT programs EXCLUDE_FROM_ALL
 +)
 -- 
-2.25.1
+2.32.0
 

--- a/recipe/0003-Include-complex.h-in-freedv_api.h-since-it-now-uses-.patch
+++ b/recipe/0003-Include-complex.h-in-freedv_api.h-since-it-now-uses-.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ryan Volz <ryan.volz@gmail.com>
+Date: Thu, 30 Sep 2021 17:48:33 -0400
+Subject: [PATCH] Include <complex.h> in freedv_api.h since it now uses
+ _Complex.
+
+---
+ src/freedv_api.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/freedv_api.h b/src/freedv_api.h
+index 23c5fef8..a70a010a 100644
+--- a/src/freedv_api.h
++++ b/src/freedv_api.h
+@@ -33,6 +33,7 @@
+ #ifndef __FREEDV_API__
+ #define __FREEDV_API__
+ 
++#include <complex.h>
+ #include <sys/types.h>
+ // This declares a single-precision (float) complex number
+ #include "comp.h"
+-- 
+2.32.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,10 @@ source:
   patches:
     - 0001-Fix-CMake-include-of-GetPrerequisites.patch
     - 0002-Add-optional-installation-of-command-line-programs.patch
+    - 0003-Include-complex.h-in-freedv_api.h-since-it-now-uses-.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
